### PR TITLE
Make HTMLEditorConfig Priorities Work

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -1405,6 +1405,7 @@ class Member extends DataObject {
 				$config = HtmlEditorConfig::get($group->HtmlEditorConfig);
 				if($config && $config->getOption('priority') > $currentPriority) {
 					$currentName = $configName;
+					$currentPriority = $config->getOption('priority');
 				}
 			}
 		}


### PR DESCRIPTION
Currently, the last HTMLEditorConfig will be the chosen config.

With this change, the one with the highest priority will be chosen as per the function's documentation.
